### PR TITLE
adding possibility to forward interpreter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ const context = useStore(s => s.state.context);
 
 This hook will only re-render when the context changes. See the [zustand docs](https://github.com/pmndrs/zustand#selecting-multiple-state-slices) for more details.
 
+## interpreter options
+
+You can hand over a second argument to `xstate` function (from this library). This is forwarded to the interpreter of xstate, thus, things like `devTools` can be enabled.

--- a/lib/xstate.ts
+++ b/lib/xstate.ts
@@ -19,9 +19,9 @@ export type Store<M> = M extends StateMachine<
   : never;
 
 const xstate =
-  <M extends StateMachine<any, any, any, any, any, any, any>>(machine: M) =>
+  <M extends StateMachine<any, any, any, any, any, any, any>>(machine: M, interpreterOptions? : Record<any,any>) =>
   (set: StoreApi<Store<M>>["setState"]): Store<M> => {
-    const service = interpret(machine)
+    const service = interpret(machine, interpreterOptions)
       .onTransition((state) => {
         const initialStateChanged =
           state.changed === undefined && Object.keys(state.children).length;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, FC } from "react";
 import { createMachine } from "xstate";
 import xstate from "../lib/xstate";
-import create from "zustand";
+import { create } from "zustand";
 import cx from "classnames";
 
 type Context = {};


### PR DESCRIPTION
It would be great to have that option to e.g. enable the devTool options.